### PR TITLE
feat: Modal 컴포넌트 -#2

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,86 @@
+'use client';
+import React from 'react';
+import ModalWrapper from './ModalWrapper';
+import styled from 'styled-components';
+import Button from '@/components/Button';
+
+interface ModalProps {
+  type: 'Ok' | 'OkCancel' | 'Action';
+  okButtonName?: string;
+  closeButtonName?: string;
+  actionButtonName?: string;
+  onOk: () => void;
+  onClose?: () => void;
+  onAction?: () => void;
+  width?: string | number;
+  children: React.ReactNode; // 유연한 내용
+}
+
+const Modal: React.FC<ModalProps> = ({
+  type = 'Ok',
+  okButtonName = '확인',
+  closeButtonName = '취소',
+  actionButtonName,
+  onOk,
+  onClose,
+  onAction,
+  width,
+  children,
+}) => {
+  return (
+    <ModalWrapper
+      width={width}
+      buttons={
+        <ButtonContainer>
+          {type === 'OkCancel' && onClose && (
+            <CancelButton onClick={onClose} name={closeButtonName} />
+          )}
+          <ConfirmButton onClick={onOk} name={okButtonName} />
+          {type === 'Action' && onAction && (
+            <ActionButton onClick={onAction}>{actionButtonName}</ActionButton>
+          )}
+        </ButtonContainer>
+      }
+    >
+      {children}
+    </ModalWrapper>
+  );
+};
+
+export default Modal;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+`;
+
+const ConfirmButton = styled(Button)`
+  flex: 1;
+  height: 50px;
+`;
+
+const CancelButton = styled(Button)`
+  flex: 1;
+  height: 50px;
+  background: ${({ theme }) => theme.colors.gray[5]};
+  &:hover {
+    background: ${({ theme }) => theme.colors.gray[5]};
+  }
+  &:active {
+    background: ${({ theme }) => theme.colors.gray[4]};
+  }
+`;
+
+const ActionButton = styled.button`
+  flex: 1 0 100%;
+  border: none;
+  outline: none;
+  background: none;
+  padding: 9px 0;
+  cursor: pointer;
+  width: 100%;
+  ${({ theme }) => theme.fonts.text['2xl']};
+  color: ${({ theme }) => theme.colors.gray[4]};
+`;

--- a/src/components/Modal/ModalWrapper.tsx
+++ b/src/components/Modal/ModalWrapper.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import styled from 'styled-components';
+
+type ModalWrapperProps = {
+  children: React.ReactNode;
+  buttons?: React.ReactNode;
+  width?: string | number;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const ModalWrapper = ({ children, buttons, width = '100%', ...props }: ModalWrapperProps) => {
+  return (
+    <StyledInputWrapper $width={width} {...props}>
+      <ModalContent>{children}</ModalContent>
+      {buttons && <Buttons>{buttons}</Buttons>}
+    </StyledInputWrapper>
+  );
+};
+
+export default ModalWrapper;
+
+const StyledInputWrapper = styled.div<{ $width: string | number }>`
+  display: flex;
+  flex-direction: column;
+  padding: 40px 16px 16px 16px;
+  width: ${({ $width }) => (typeof $width === 'number' ? `${$width}px` : $width)};
+  border-radius: 15px;
+  background: white;
+  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.2);
+`;
+
+const ModalContent = styled.div`
+  flex: 1;
+  width: 100%;
+  text-align: center;
+  margin-bottom: 40px;
+`;
+
+const Buttons = styled.div`
+  width: 100%;
+  display: flex;
+`;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/src/components/Modal/modalTypography.ts
+++ b/src/components/Modal/modalTypography.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const Text = styled.span`
+  ${({ theme }) => theme.fonts.title['sm']};
+  text-align: center;
+`;
+
+export const Emphasize = styled.span`
+  color: ${({ theme }) => theme.colors.primary.default};
+`;
+
+export const DisabledText = styled.span`
+  margin-top: 20px;
+  display: block;
+  ${({ theme }) => theme.fonts.text['2xl']};
+  color: ${({ theme }) => theme.colors.gray[4]};
+`;
+
+export const LargeText = styled.span`
+  ${({ theme }) => theme.fonts.title['xl']};
+  text-align: center;
+`;


### PR DESCRIPTION
Modal 컴포넌트 하나만으로 이용 가능하도록 타입을 정의했습니다.
그리고 사용될 텍스트를 미리 modalTypography.ts에 정의했습니다.

## 프로퍼티 설명
- `type` : Ok, OkCancel, Action (기본값은 Ok)
- `okButtonName` : (기본값 확인)
- `closeButtonName` : (기본값 취소)
- `actionButtonName` : 회색 글씨 버튼을 액션 버튼이라고 명명했어요.
- `onOk` : OK 버튼 콜백
- `onClose` : 취소 버튼 콜백
- `onAction` : 액션 버튼 콜백
- `width`
- `children`

자세한 예시는 Issue에 댓글로 남겨두었습니다.