### PR TITLE
feat: 마이페이지 UI -#32

### DIFF
--- a/src/app/mypage/badge/page.tsx
+++ b/src/app/mypage/badge/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import TabBar from '@/components/TabBar';
+import React from 'react';
+import BadgeCollection from '@/features/mypage/BadgeCollection';
+
+const BadgeListPage = () => {
+  return (
+    <>
+      <TabBar />
+      <BadgeCollection />
+    </>
+  );
+};
+export default BadgeListPage;

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+import MyPageProfileIcon from '@/features/mypage/MyPageProfileIcon/MyPageProfileIcon';
+import TabBar from '@/components/TabBar';
+import { useInputState } from '@/hooks/useInputState';
+import MyPageNicknameInput from '@/features/mypage/MyPageNicknameInput';
+import OwnedBadgeGrid from '@/features/mypage/OwnedBadgeGrid';
+import ColorPalette from '@/features/mypage/ColorPalette';
+
+const EditMyPage = () => {
+  const nickname = useInputState();
+
+  return (
+    <>
+      <TabBar />
+      <Container>
+        <MyPageProfileIcon />
+        <MyPageNicknameInput nickname={nickname} />
+        <OwnedBadgeGrid />
+        <ColorPalette />
+      </Container>
+    </>
+  );
+};
+export default EditMyPage;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,0 +1,9 @@
+import BasicLayout from '@/components/Layouts/BasicLayout';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function HomeLayout({ children }: Props) {
+  return <BasicLayout>{children}</BasicLayout>;
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import TabBar from '@/components/TabBar';
+import { useRouter } from 'next/navigation';
+import styled from 'styled-components';
+import React from 'react';
+import BottomNavigation from '@/components/BottomNavigation';
+import MyPageCounter from '@/features/mypage/MyPageCounter';
+import MyPageProfileIcon from '@/features/mypage/MyPageProfileIcon/MyPageProfileIcon';
+import NicknameButton from '@/features/mypage/NicknameButton/NicknameButton';
+
+const MyPage = () => {
+  const router = useRouter();
+  return (
+    <>
+      <TabBar
+        leftType="logo"
+        rightType="settingBtn"
+        onClick={() => router.push('/mypage/setting')}
+      />
+      <Container>
+        <MyPageProfileIcon />
+        <NicknameButton />
+        <MyPageCounter />
+      </Container>
+      <BottomNavigation tab="mypage" />
+    </>
+  );
+};
+
+export default MyPage;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/src/app/mypage/setting/page.tsx
+++ b/src/app/mypage/setting/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import TabBar from '@/components/TabBar';
+import styled from 'styled-components';
+import SettingListItem from '@/features/mypage/SettingListItem';
+
+const SettingMyPage = () => {
+  return (
+    <>
+      <TabBar />
+      <Container>
+        <SettingListItem
+          name="계정 관리"
+          showButton={true}
+          onClick={() => {
+            console.log('계정 관리 페이지 이동(TBD)');
+          }}
+        />
+        <SettingListItem
+          name="약관 및 정책"
+          showButton={true}
+          onClick={() => {
+            console.log('약관 및 정책 페이지 이동(TBD)');
+          }}
+        />
+        <SettingListItem
+          name="로그아웃"
+          onClick={() => {
+            console.log('로그아웃');
+          }}
+        />
+        <SettingListItem
+          name="탈퇴하기"
+          onClick={() => {
+            console.log('탈퇴');
+          }}
+        />
+      </Container>
+    </>
+  );
+};
+export default SettingMyPage;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/assets/profileIcons/svg/index.ts
+++ b/src/assets/profileIcons/svg/index.ts
@@ -1,0 +1,12 @@
+export { default as Icon1 } from './1.svg';
+export { default as Icon2 } from './2.svg';
+export { default as Icon3 } from './3.svg';
+export { default as Icon4 } from './4.svg';
+export { default as Icon5 } from './5.svg';
+export { default as Icon6 } from './6.svg';
+export { default as Icon7 } from './7.svg';
+export { default as Icon8 } from './8.svg';
+export { default as Icon9 } from './9.svg';
+export { default as Icon10 } from './10.svg';
+export { default as Icon11 } from './11.svg';
+export { default as Icon12 } from './12.svg';

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -3,28 +3,20 @@ import MemaIcon from '@/assets/icons/svg/mema.svg';
 import SelectedMemaIcon from '@/assets/icons/svg/memaFilled.svg';
 import CalendarIcon from '@/assets/icons/svg/calendar.svg';
 import SelectedCalendarIcon from '@/assets/icons/svg/calendarFilled.svg';
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
-const BottomNavigation = () => {
-  const [activeTab, setActiveTab] = useState<'calendar' | 'mema'>('calendar');
-
+type Props = {
+  tab?: 'calendar' | 'mypage';
+};
+const BottomNavigation = ({ tab = 'calendar' }: Props) => {
+  const router = useRouter();
   return (
     <Container>
-      <NavItem
-        onClick={() => {
-          setActiveTab('calendar');
-          alert('캘린더 클릭');
-        }}
-      >
-        {activeTab === 'calendar' ? <SelectedCalendarIcon /> : <CalendarIcon />}
+      <NavItem onClick={() => router.push('/')}>
+        {tab === 'calendar' ? <SelectedCalendarIcon /> : <CalendarIcon />}
       </NavItem>
-      <NavItem
-        onClick={() => {
-          setActiveTab('mema');
-          alert('메마 클릭');
-        }}
-      >
-        {activeTab === 'mema' ? <SelectedMemaIcon /> : <MemaIcon />}
+      <NavItem onClick={() => router.push('/mypage')}>
+        {tab === 'mypage' ? <SelectedMemaIcon /> : <MemaIcon />}
       </NavItem>
     </Container>
   );
@@ -37,7 +29,8 @@ const Container = styled.div`
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-  width: 390px;
+  width: 100%;
+  max-width: 390px;
   background-color: white;
   border-top: 1px solid ${({ theme }) => theme.colors.gray[5]};
   z-index: ${({ theme }) => theme.zIndex.navigation};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -18,6 +18,7 @@ const StyledInput = styled.input`
   border: none;
   outline: none;
   padding: 0;
+  background-color: transparent;
   ${({ theme }) => theme.fonts.text['2xl']};
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray[4]};

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 import { ChevronLeft } from 'react-feather';
 import { useRouter } from 'next/navigation';
 import Logo from '/public/svgs/common/logo.svg';
-import { ExternalLink } from 'react-feather';
+import { ExternalLink, Settings } from 'react-feather';
 import Link from 'next/link';
 
 type Props = {
   leftType?: 'logo' | 'backBtn';
-  rightType?: 'shareBtn';
+  rightType?: 'shareBtn' | 'settingBtn';
   onClick?: () => void;
   onClickBack?: () => void;
 };
@@ -28,6 +28,7 @@ function TabBar({ leftType = 'backBtn', rightType, onClick, onClickBack }: Props
         <ChevronLeft onClick={handleBack} />
       )}
       {rightType === 'shareBtn' && <ExternalLink onClick={onClick} />}
+      {rightType === 'settingBtn' && <SettingsIcon onClick={onClick} />}
     </Container>
   );
 }
@@ -40,6 +41,10 @@ const Container = styled.div`
   svg {
     cursor: pointer;
   }
+`;
+
+const SettingsIcon = styled(Settings)`
+  stroke: ${({ theme }) => theme.colors.gray[4]};
 `;
 
 export default TabBar;

--- a/src/components/common/MemberIcon.tsx
+++ b/src/components/common/MemberIcon.tsx
@@ -34,6 +34,8 @@ type MemberIconProps = {
   puzzleColor: string;
   size: number;
   showShadow?: boolean;
+  disabled?: boolean;
+  selected?: boolean;
 };
 
 const MemberIcon: React.FC<MemberIconProps> = ({
@@ -41,6 +43,8 @@ const MemberIcon: React.FC<MemberIconProps> = ({
   puzzleColor,
   size = 40,
   showShadow = false,
+  disabled = false,
+  selected = false,
 }) => {
   const IconComponent = iconMap[puzzleId];
   if (!IconComponent) {
@@ -48,7 +52,13 @@ const MemberIcon: React.FC<MemberIconProps> = ({
   }
 
   return (
-    <IconWrapper $size={size} $color={puzzleColor} $showShadow={showShadow}>
+    <IconWrapper
+      $size={size}
+      $color={puzzleColor}
+      $showShadow={showShadow}
+      $disabled={disabled}
+      $selected={selected}
+    >
       <IconComponent />
     </IconWrapper>
   );
@@ -56,7 +66,13 @@ const MemberIcon: React.FC<MemberIconProps> = ({
 
 export default MemberIcon;
 
-const IconWrapper = styled.div<{ $size: number; $color: string; $showShadow: boolean }>`
+const IconWrapper = styled.div<{
+  $size: number;
+  $color: string;
+  $showShadow: boolean;
+  $disabled: boolean;
+  $selected: boolean;
+}>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -66,6 +82,9 @@ const IconWrapper = styled.div<{ $size: number; $color: string; $showShadow: boo
   ${({ $showShadow }) =>
     $showShadow && `box-shadow: 1.667px 0px 8.333px 0px rgba(0, 0, 0, 0.06);`} /* 그림자 */
 
+  opacity: ${({ $disabled }) => ($disabled ? 0.35 : 1)};
+  border: ${({ $selected, theme }) =>
+    $selected ? `2px solid ${theme.colors.primary.default}` : 'none'};
   svg {
     width: 100%;
     height: 100%;

--- a/src/features/mypage/BadgeCollection/BadgeCollection.tsx
+++ b/src/features/mypage/BadgeCollection/BadgeCollection.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+import {
+  Icon1,
+  Icon2,
+  Icon3,
+  Icon4,
+  Icon5,
+  Icon6,
+  Icon7,
+  Icon8,
+  Icon9,
+  Icon10,
+  Icon11,
+  Icon12,
+} from '@/assets/profileIcons/svg';
+import React from 'react';
+
+const badges = [
+  { Icon: Icon1, goal: '메마 첫 가입' },
+  { Icon: Icon2, goal: '첫 모임 생성' },
+  { Icon: Icon3, goal: '메마 방문 5회' },
+  { Icon: Icon4, goal: '메마 방문 20회' },
+  { Icon: Icon5, goal: '메이트 3회 생성' },
+  { Icon: Icon6, goal: '메이트 5회 생성' },
+  { Icon: Icon7, goal: '미팅 3회 생성' },
+  { Icon: Icon8, goal: '미팅 5회 생성' },
+  { Icon: Icon9, goal: '정산 3회 이용' },
+  { Icon: Icon10, goal: '정산 10회 이용' },
+  { Icon: Icon11, goal: '코드 5회 공유' },
+  { Icon: Icon12, goal: '코드 20회 공유' },
+];
+
+const BadgeCollection = () => {
+  return (
+    <BadgeContainer>
+      {badges.map(({ Icon, goal }, index) => (
+        <BadgeItem key={index}>
+          <Icon />
+          <p className="title">{goal}</p>
+        </BadgeItem>
+      ))}
+    </BadgeContainer>
+  );
+};
+export default BadgeCollection;
+
+const BadgeContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 10px 0 64px;
+`;
+
+const BadgeItem = styled.div`
+  background-color: ${({ theme }) => theme.colors.gray[6]};
+  border-radius: 15px;
+  padding: 16px 12px;
+  svg {
+    fill: ${({ theme }) => theme.colors.primary.default};
+    width: 150px;
+    height: 150px;
+    margin-bottom: 16px;
+  }
+  .title {
+    text-align: center;
+    ${({ theme }) => theme.fonts.title['xs']};
+  }
+`;

--- a/src/features/mypage/BadgeCollection/index.tsx
+++ b/src/features/mypage/BadgeCollection/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './BadgeCollection';

--- a/src/features/mypage/ColorPalette/ColorPalette.tsx
+++ b/src/features/mypage/ColorPalette/ColorPalette.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import GrayBoxContainer from '@/features/mypage/GrayBoxContainer';
+import styled from 'styled-components';
+
+const ColorPalette = () => {
+  const colors = ['blue', 'red', 'yellow', 'green', 'purple', 'black'];
+  const selectedColor = 'green';
+
+  return (
+    <GrayBoxContainer>
+      <p className="title">뱃지 컬러</p>
+      <ColorChipGrid>
+        {colors.map((color) => (
+          <ColorChip key={color} $color={color}>
+            {color === selectedColor && <InnerCircle />}
+          </ColorChip>
+        ))}
+      </ColorChipGrid>
+    </GrayBoxContainer>
+  );
+};
+
+export default ColorPalette;
+
+const ColorChipGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+  justify-items: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const ColorChip = styled.div<{ $color: string }>`
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  position: relative;
+  background-color: ${({ theme, $color }) => theme.colors[$color]};
+`;
+
+const InnerCircle = styled.div`
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  background-color: transparent;
+  box-sizing: border-box;
+  border: 2px solid white;
+  border-radius: 50%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/features/mypage/ColorPalette/index.tsx
+++ b/src/features/mypage/ColorPalette/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ColorPalette';

--- a/src/features/mypage/GrayBoxContainer.tsx
+++ b/src/features/mypage/GrayBoxContainer.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const GrayBoxContainer = styled.div`
+  padding: 16px;
+  box-sizing: border-box;
+  border-radius: 15px;
+  width: 100%;
+  background-color: ${({ theme }) => theme.colors.gray[6]};
+
+  .title {
+    ${({ theme }) => theme.fonts.title.xs};
+    margin-bottom: 10px;
+  }
+`;
+
+export default GrayBoxContainer;

--- a/src/features/mypage/MyPageCounter/MyPageCounter.tsx
+++ b/src/features/mypage/MyPageCounter/MyPageCounter.tsx
@@ -1,0 +1,52 @@
+'use client';
+import styled from 'styled-components';
+import React from 'react';
+
+const MyPageCounter = () => {
+  return (
+    <Container>
+      <CounterItem>
+        <p className="countText">12</p>
+        <p className="title">미팅 수</p>
+      </CounterItem>
+      <CounterItem>
+        <p className="countText">36</p>
+        <p className="title">메마 방문 수</p>
+      </CounterItem>
+      <CounterItem>
+        <p className="countText">2</p>
+        <p className="title">내 뱃지 수</p>
+      </CounterItem>
+    </Container>
+  );
+};
+
+export default MyPageCounter;
+
+const Container = styled.div`
+  display: flex;
+  width: calc(100% - 32px);
+  height: 90px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: ${({ theme }) => theme.borderRadius.medium};
+  background-color: ${({ theme }) => theme.colors.gray[6]};
+`;
+
+const CounterItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  flex: 1;
+  .countText {
+    ${({ theme }) => theme.fonts.title.lg};
+    color: ${({ theme }) => theme.colors.primary.default};
+  }
+  .title {
+    ${({ theme }) => theme.fonts.text.lg};
+    color: ${({ theme }) => theme.colors.gray[3]};
+  }
+`;

--- a/src/features/mypage/MyPageCounter/index.tsx
+++ b/src/features/mypage/MyPageCounter/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './MyPageCounter';

--- a/src/features/mypage/MyPageNicknameInput/MyPageNicknameInput.tsx
+++ b/src/features/mypage/MyPageNicknameInput/MyPageNicknameInput.tsx
@@ -1,0 +1,34 @@
+import InputWrapper from '@/components/Input/InputWrapper';
+import Input from '@/components/Input';
+import React from 'react';
+import styled from 'styled-components';
+import { UseInputStateReturn } from '@/hooks/useInputState';
+import GrayBoxContainer from '@/features/mypage/GrayBoxContainer';
+
+type Props = {
+  nickname: UseInputStateReturn;
+};
+
+const MyPageNicknameInput = ({ nickname }: Props) => {
+  return (
+    <Container>
+      <p className="title">닉네임</p>
+      <InputWrapper isFocused={nickname.isFocused} isEmpty={nickname.isEmpty}>
+        <Input
+          type="text"
+          value={nickname.value}
+          placeholder="닉네임을 입력하세요"
+          onChange={nickname.handleChange}
+          onFocus={nickname.handleFocus}
+          onBlur={nickname.handleBlur}
+        />
+      </InputWrapper>
+    </Container>
+  );
+};
+
+export default MyPageNicknameInput;
+
+const Container = styled(GrayBoxContainer)`
+  margin: 20px 0 10px;
+`;

--- a/src/features/mypage/MyPageNicknameInput/index.tsx
+++ b/src/features/mypage/MyPageNicknameInput/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './MyPageNicknameInput';

--- a/src/features/mypage/MyPageProfileIcon/MyPageProfileIcon.tsx
+++ b/src/features/mypage/MyPageProfileIcon/MyPageProfileIcon.tsx
@@ -1,0 +1,23 @@
+'use client';
+import styled from 'styled-components';
+import React from 'react';
+import MemberIcon from '@/components/common/MemberIcon';
+
+const MyPageProfileIcon = () => {
+  return (
+    <Container>
+      <MemberIcon puzzleId={1} puzzleColor="green" size={150} />
+    </Container>
+  );
+};
+
+export default MyPageProfileIcon;
+
+const Container = styled.div`
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  border: 3px solid ${({ theme }) => theme.colors.gray[5]};
+  flex-shrink: 0;
+  margin: 20px 0;
+`;

--- a/src/features/mypage/MyPageProfileIcon/index.tsx
+++ b/src/features/mypage/MyPageProfileIcon/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './MyPageProfileIcon';

--- a/src/features/mypage/NicknameButton/NicknameButton.tsx
+++ b/src/features/mypage/NicknameButton/NicknameButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import styled from 'styled-components';
+import { ChevronRight } from 'react-feather';
+import React from 'react';
+
+const NicknameButton = () => {
+  const router = useRouter();
+  return (
+    <Container onClick={() => router.push('/mypage/edit')}>
+      쌈뽕한 메마러버
+      <ChevronRight />
+    </Container>
+  );
+};
+
+export default NicknameButton;
+
+const Container = styled.div`
+  ${({ theme }) => theme.fonts.title.lg};
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 30px;
+  cursor: pointer;
+`;

--- a/src/features/mypage/NicknameButton/index.tsx
+++ b/src/features/mypage/NicknameButton/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './NicknameButton';

--- a/src/features/mypage/OwnedBadgeGrid/OwnedBadgeGrid.tsx
+++ b/src/features/mypage/OwnedBadgeGrid/OwnedBadgeGrid.tsx
@@ -1,0 +1,58 @@
+import { ChevronRight } from 'react-feather';
+import MemberIcon from '@/components/common/MemberIcon';
+import React from 'react';
+import styled from 'styled-components';
+import { useRouter } from 'next/navigation';
+import GrayBoxContainer from '@/features/mypage/GrayBoxContainer';
+
+const OwnedBadgeGrid = () => {
+  const router = useRouter();
+  return (
+    <BadgeContainer>
+      <ProfileBadgeTitle>
+        <p className="title">프로필 뱃지</p>
+        <ChevronRight
+          onClick={() => {
+            router.push('/mypage/badge');
+          }}
+        />
+      </ProfileBadgeTitle>
+      <BadgeIconGrid>
+        <MemberIcon puzzleId={1} puzzleColor="blue" size={74} selected={true} />
+        <MemberIcon puzzleId={2} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={3} puzzleColor="blue" size={74} disabled={true} />
+        <MemberIcon puzzleId={4} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={5} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={6} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={7} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={8} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={9} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={10} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={11} puzzleColor="blue" size={74} />
+        <MemberIcon puzzleId={12} puzzleColor="blue" size={74} />
+      </BadgeIconGrid>
+    </BadgeContainer>
+  );
+};
+export default OwnedBadgeGrid;
+
+const BadgeContainer = styled(GrayBoxContainer)`
+  margin-bottom: 10px;
+`;
+
+const ProfileBadgeTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  svg {
+    padding: 4px;
+    cursor: pointer;
+  }
+`;
+
+const BadgeIconGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  justify-items: center;
+  align-items: center;
+`;

--- a/src/features/mypage/OwnedBadgeGrid/index.tsx
+++ b/src/features/mypage/OwnedBadgeGrid/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './OwnedBadgeGrid';

--- a/src/features/mypage/SettingListItem/SettingListItem.tsx
+++ b/src/features/mypage/SettingListItem/SettingListItem.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ChevronRight } from 'react-feather';
+import styled from 'styled-components';
+
+type Props = {
+  name: string;
+  showButton?: boolean;
+  onClick?: () => void;
+};
+
+const SettingListItem = ({ name, showButton = false, onClick }: Props) => {
+  return (
+    <Container onClick={onClick}>
+      {name}
+      {showButton && <RightIcon />}
+    </Container>
+  );
+};
+
+export default SettingListItem;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  ${({ theme }) => theme.fonts.text['2xl']};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray[6]};
+  cursor: pointer;
+`;
+
+const RightIcon = styled(ChevronRight)`
+  stroke: ${({ theme }) => theme.colors.gray[4]};
+`;

--- a/src/features/mypage/SettingListItem/index.tsx
+++ b/src/features/mypage/SettingListItem/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SettingListItem';


### PR DESCRIPTION
### 🌐 라우트
- 마이페이지 : /mypage
- 프로필 수정 : /mypage/edit
- 마이페이지 뱃지 리스트 : /mypage/badge
- 마이페이지 설정 : /mypage/setting

### ✏️ 작업한 내용
- [x]  마이페이지
    - [x]  미팅 수, 메마 방문 횟수, 뱃지 개수 카운팅 컴포넌트
- [x]  프로필 수정 페이지
    - [x]  닉네임 인풋
    - [x]  프로필 뱃지 리스트
    - [x]  뱃지 컬러 리스트 그리드
- [x]  뱃지 리스트 조회 페이지
    - [x]  뱃지 리스트 그리드
    - [x]  뱃지 컴포넌트
- [x]  마이페이지 - 설정 페이지
    - [x]  리스트 아이템 컴포넌트
 
### 추가 사항
- 하단 내비게이션 바 줄어들지 않는 버그 수정하였습니다.