### PR TITLE
feat: 로그인, 회원가입 API 연동 -#42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
         "react-feather": "^2.0.10",
-        "styled-components": "^6.1.13"
+        "styled-components": "^6.1.13",
+        "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",
@@ -19752,6 +19753,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
+      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",
     "react-feather": "^2.0.10",
-    "styled-components": "^6.1.13"
+    "styled-components": "^6.1.13",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import IntroButtons from '@/features/Intro/IntroButtons';
 import WelcomeHeader from '@/features/Intro/WelcomeHeader';
@@ -7,50 +7,53 @@ import TabBar from '@/components/TabBar';
 import Button from '@/components/Button';
 import { useRouter } from 'next/navigation';
 import MeetingHistoryNull from '@/features/home/main/MeetingHistoryNull';
-import BottomNavigation from '../../components/BottomNavigation';
+import BottomNavigation from '@/components/BottomNavigation';
 import { ChevronRight } from 'react-feather';
 import MeetingHistoryGrid from '@/features/home/main/MeetingHistoryGrid';
 
 export default function Home() {
-  const isLoggedIn = true;
   const router = useRouter();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('authToken');
+    if (token) {
+      setIsAuthenticated(true);
+    }
+  }, []);
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        <WelcomeHeader />
+        <IntroButtons />
+      </>
+    );
+  }
+
   return (
     <>
-      {isLoggedIn ? (
-        <div>
-          <TabBar leftType="logo" />
-          <Button
-            buttonType="ghost"
-            name="참여코드 입력하기"
-            onClick={() => router.push('/meet/join')}
-          />
-          {/*<MeetingHistoryNull />*/}
-          <RecentMeetingTitle>
-            <p>최근 미팅 내역</p>
-            <ChevronRight
-              onClick={() => {
-                router.push('/meet/management');
-              }}
-            />
-          </RecentMeetingTitle>
-          <MeetingHistoryGrid />
-          <StyledButton name="미팅 만들기" onClick={() => router.push('/meet/create')} />
-          <BottomNavigation />
-        </div>
-      ) : (
-        <Container>
-          <WelcomeHeader />
-          <IntroButtons />
-        </Container>
-      )}
+      <TabBar leftType="logo" />
+      <Button
+        buttonType="ghost"
+        name="참여코드 입력하기"
+        onClick={() => router.push('/meet/join')}
+      />
+      {/*<MeetingHistoryNull />*/}
+      <RecentMeetingTitle>
+        <p>최근 미팅 내역</p>
+        <ChevronRight
+          onClick={() => {
+            router.push('/meet/management');
+          }}
+        />
+      </RecentMeetingTitle>
+      <MeetingHistoryGrid />
+      <StyledButton name="미팅 만들기" onClick={() => router.push('/meet/create')} />
+      <BottomNavigation />
     </>
   );
 }
-
-const Container = styled.div`
-  text-align: center;
-  position: absolute;
-`;
 
 const StyledButton = styled(Button)`
   position: fixed;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,12 +10,13 @@ import Logo from '/public/svgs/common/logo.svg';
 import TitleWithDescription from '@/components/common/TitleWithDescription';
 import { useMutation } from '@tanstack/react-query';
 import { login } from '@/lib/api/account';
-import { setUserRole } from '@/lib/api/defaultAxios';
+import { useUserRoleStore } from '@/store/userRoleStore';
 
 const LoginPage = () => {
   const router = useRouter();
   const email = useInputState();
   const password = useInputState();
+  const { userRole, setUserRole } = useUserRoleStore();
 
   const loginMutation = useMutation({
     mutationFn: login,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,11 +8,36 @@ import { useInputState } from '@/hooks/useInputState';
 import Button from '@/components/Button';
 import Logo from '/public/svgs/common/logo.svg';
 import TitleWithDescription from '@/components/common/TitleWithDescription';
+import { useMutation } from '@tanstack/react-query';
+import { login } from '@/lib/api/account';
+import { setUserRole } from '@/lib/api/defaultAxios';
 
 const LoginPage = () => {
   const router = useRouter();
-  const emailInputState = useInputState();
-  const passwordInputState = useInputState();
+  const email = useInputState();
+  const password = useInputState();
+
+  const loginMutation = useMutation({
+    mutationFn: login,
+    onSuccess: () => {
+      setUserRole('ROLE_CUSTOM');
+      router.push('/');
+    },
+    onError: (error) => {
+      console.error('Login failed:', error);
+      alert('로그인 실패');
+    },
+  });
+
+  const handleLogin = () => {
+    if (!(email.value && password.value)) return;
+    loginMutation.mutate({ email: email.value, password: password.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handleLogin();
+  };
 
   return (
     <>
@@ -27,14 +52,18 @@ const LoginPage = () => {
         }
         description="회원 서비스 이용을 위해 로그인 해주세요!"
       />
-      <LoginForm email={emailInputState} password={passwordInputState} />
-      <StyledButton
-        name="로그인하기"
-        disabled={!(emailInputState.value && passwordInputState.value)}
-        onClick={() => {
-          console.log('로그인 요청 API 호출');
-        }}
-      />
+      <form onSubmit={handleSubmit}>
+        <LoginForm email={email} password={password} />
+        <StyledButton name="로그인하기" type="submit" disabled={!(email.value && password.value)} />
+      </form>
+
+      {/*<LoginForm email={email} password={password} />*/}
+      {/*<StyledButton*/}
+      {/*  name="로그인하기"*/}
+      {/*  type="submit"*/}
+      {/*  disabled={!(email.value && password.value)}*/}
+      {/*  onClick={handleLogin}*/}
+      {/*/>*/}
     </>
   );
 };

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -13,6 +13,8 @@ import EmailVerificationInputs from '@/features/account/EmailVerificationInputs'
 import styled from 'styled-components';
 import Button from '@/components/Button';
 import PasswordInput from '@/features/account/PasswordInput';
+import { useMutation } from '@tanstack/react-query';
+import { signup } from '@/lib/api/account';
 
 const SignupPage = () => {
   const router = useRouter();
@@ -39,6 +41,26 @@ const SignupPage = () => {
     setVerification(!isVerified);
   };
 
+  const signupMutation = useMutation({
+    mutationFn: signup,
+    onSuccess: () => {
+      toggleOpenModal();
+    },
+    onError: (error) => {
+      console.error('Signup failed:', error);
+      alert('회원가입 실패');
+    },
+  });
+
+  const handleSignup = () => {
+    if (!(email.value && password.value && nickname.value)) return;
+    signupMutation.mutate({
+      email: email.value,
+      password: password.value,
+      nickname: nickname.value,
+    });
+  };
+
   const steps = [
     {
       id: 1,
@@ -61,7 +83,7 @@ const SignupPage = () => {
     },
     {
       id: 2,
-      content: <NicknameInput nickname={nickname} onClickNext={toggleOpenModal} />,
+      content: <NicknameInput nickname={nickname} onClickNext={handleSignup} />,
       description: '메마에서 사용하실 닉네임을 알려주세요!',
     },
   ];

--- a/src/features/Intro/IntroButtons/IntroButtons.tsx
+++ b/src/features/Intro/IntroButtons/IntroButtons.tsx
@@ -18,7 +18,7 @@ const IntroButtons = () => {
   return (
     <ButtonContainer>
       <NaverLoginButton onClick={handleNaverLogin}>
-        <NaverLogo className="logo" />
+        <NaverLogo />
         네이버로 로그인
       </NaverLoginButton>
       <StyledCustomButton name="이메일로 로그인" onClick={() => router.push('/login')} />
@@ -37,16 +37,18 @@ const ButtonContainer = styled.div`
   position: absolute;
   display: flex;
   flex-direction: column;
+  align-items: center;
   bottom: 138px;
   width: calc(100% - 32px);
   gap: 8px;
-  .logo {
+  svg {
     margin-right: 16px;
   }
 `;
 
 const NaverLoginButton = styled.button`
   height: 55px;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -61,7 +63,7 @@ const NaverLoginButton = styled.button`
         background-color: #ABDBC1;
       }
       &:active {
-        background-color: ${theme.colors.primary.darker};
+        background-color: #028a48;
         color: ${theme.colors.darker};
       }
       &:disabled {

--- a/src/features/Intro/WelcomeHeader/WelcomeHeader.tsx
+++ b/src/features/Intro/WelcomeHeader/WelcomeHeader.tsx
@@ -25,9 +25,9 @@ const WelcomeHeader = () => {
 export default WelcomeHeader;
 
 const TextOveray = styled.div`
-  width: calc(100% - 32px);
   position: absolute;
   transform: translateY(-50%);
+  width: calc(100% - 32px);
   text-align: center;
   .title {
     ${({ theme }) => theme.fonts.title.lg}

--- a/src/hooks/useInputState.ts
+++ b/src/hooks/useInputState.ts
@@ -11,7 +11,7 @@ export interface UseInputStateReturn {
   handleFocus: () => void;
   handleBlur: () => void;
   handleChange: (newValue: string) => void;
-  setValue: Dispatch<SetStateAction<any>>;
+  setValue: Dispatch<SetStateAction<string>>;
 }
 
 export const useInputState = ({ validate }: UseInputStateParams = {}): UseInputStateReturn => {

--- a/src/lib/api/account.ts
+++ b/src/lib/api/account.ts
@@ -1,0 +1,27 @@
+import { defaultAxios } from '@/lib/api/defaultAxios';
+
+// 로그인
+export const login = async (data: { email: string; password: string }) => {
+  const response = await defaultAxios.post(`/login`, data);
+  if (typeof window !== 'undefined') {
+    const authToken = response.headers['authentication'].slice(7); // 'Bearer '제거
+    if (authToken) {
+      localStorage.setItem('authToken', authToken);
+    } else {
+      console.error('Authentication token is missing in headers');
+    }
+  }
+  return response.data;
+};
+
+// 회원가입
+export const signup = async (data: { email: string; password: string; nickname: string }) => {
+  const response = await defaultAxios.post(`/join/custom`, data);
+  return response.data;
+};
+
+// 유저 정보 조회
+export const getUser = async () => {
+  const response = await defaultAxios.get(`/mypage`);
+  return response.data;
+};

--- a/src/lib/api/defaultAxios.ts
+++ b/src/lib/api/defaultAxios.ts
@@ -1,8 +1,40 @@
 import axios from 'axios';
+import { redirect } from 'next/navigation';
 
-const baseURL = `${process.env.REACT_APP_SERVER_URL}`;
+const baseURL = `${process.env.NEXT_PUBLIC_SERVER_URL}`;
 
 export const defaultAxios = axios.create({
   baseURL,
   withCredentials: true,
 });
+
+let userRole: 'ROLE_CUSTOM' | 'ROLE_NAVER' = 'ROLE_NAVER';
+
+export const setUserRole = (role: 'ROLE_CUSTOM' | 'ROLE_NAVER') => {
+  userRole = role;
+};
+
+// Request Interceptor
+defaultAxios.interceptors.request.use((config) => {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+  if (userRole === 'ROLE_CUSTOM' && token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// Response Interceptor
+defaultAxios.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('authToken');
+        redirect('/');
+      }
+    }
+    return Promise.reject(error);
+  },
+);

--- a/src/store/userRoleStore.ts
+++ b/src/store/userRoleStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type UserRole = 'ROLE_CUSTOM' | 'ROLE_NAVER';
+
+interface UserRoleState {
+  userRole: UserRole;
+  setUserRole: (role: UserRole) => void;
+}
+
+export const useUserRoleStore = create<UserRoleState>((set) => ({
+  userRole: 'ROLE_NAVER', // 초기값
+  setUserRole: (role) => set({ userRole: role }),
+}));

--- a/src/types/ErrorResponse.ts
+++ b/src/types/ErrorResponse.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponse {
+  code: string;
+  message: string;
+}


### PR DESCRIPTION
### ✏️ 작업한 내용
- [x] 로그인 API 연동
- [x] 회원가입 API 연동
- [x] 메인페이지에 로그인 여부 검토 후 화면 띄워주기
- [x] 만료된 토큰으로 API 날리면 토큰 삭제 및 메인 페이지로 이동
- [x] Zustand로 로그인 방식 저장

### 📋 Note
- 네이버 소셜 로그인, 커스텀 로그인 인증 방식이 다름
    - 네이버 : 쿠키 방식
    - 커스텀 로그인 : 헤더 방식
 - 로그인 방식에 따라 요청 보낼 때 타입에 따라 보내도록 Request Interceptor에서 처리함.