### PR TITLE
feat: 홈 메인화면 API 연동 -#43

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -10,10 +10,19 @@ import MeetingHistoryNull from '@/features/home/main/MeetingHistoryNull';
 import BottomNavigation from '@/components/BottomNavigation';
 import { ChevronRight } from 'react-feather';
 import MeetingHistoryGrid from '@/features/home/main/MeetingHistoryGrid';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { HomeMeetsResponse } from '@/types/meets';
+import { getHomeMeets } from '@/lib/api/meets';
+import Modal from '@/components/Modal';
+import { DisabledText, Emphasize, Text } from '@/components/Modal/modalTypography';
+import useToggle from '@/lib/hooks/useToggle';
+import { MAX_UPCOMMING_MEET_COUNT } from '@/constants/meetConst';
 
 export default function Home() {
   const router = useRouter();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isOpenModal, toggleModal] = useToggle();
 
   useEffect(() => {
     const token = localStorage.getItem('authToken');
@@ -21,6 +30,12 @@ export default function Home() {
       setIsAuthenticated(true);
     }
   }, []);
+
+  const { data: meets } = useQuery<AxiosResponse<HomeMeetsResponse>>({
+    queryKey: ['meets'],
+    queryFn: getHomeMeets,
+    enabled: isAuthenticated,
+  });
 
   if (!isAuthenticated) {
     return (
@@ -30,6 +45,15 @@ export default function Home() {
       </>
     );
   }
+  if (!meets) return;
+
+  const meetingCreateHandler = () => {
+    if (meets.data.upcomingMeets.length < MAX_UPCOMMING_MEET_COUNT) {
+      router.push('/meet/create');
+    } else {
+      toggleModal();
+    }
+  };
 
   return (
     <>
@@ -39,18 +63,35 @@ export default function Home() {
         name="참여코드 입력하기"
         onClick={() => router.push('/meet/join')}
       />
-      {/*<MeetingHistoryNull />*/}
-      <RecentMeetingTitle>
-        <p>최근 미팅 내역</p>
-        <ChevronRight
-          onClick={() => {
-            router.push('/meet/management');
-          }}
-        />
-      </RecentMeetingTitle>
-      <MeetingHistoryGrid />
-      <StyledButton name="미팅 만들기" onClick={() => router.push('/meet/create')} />
+      {meets.data.upcomingMeets.length === 0 && meets.data.pastMeets.length === 0 ? (
+        <MeetingHistoryNull />
+      ) : (
+        <>
+          <RecentMeetingTitle>
+            <p>최근 미팅 내역</p>
+            <ChevronRight
+              onClick={() => {
+                router.push('/meet/management');
+              }}
+            />
+          </RecentMeetingTitle>
+          <MeetingHistoryGrid meets={meets.data} />
+        </>
+      )}
+      <StyledButton name="미팅 만들기" onClick={meetingCreateHandler} />
       <BottomNavigation />
+      {isOpenModal && (
+        <Modal type="Ok" onOk={toggleModal} width={326}>
+          <Text>
+            미팅은 <Emphasize>최대 4개</Emphasize>까지 생성 가능해요!
+          </Text>
+          <DisabledText>
+            기존 미팅이 끝나면
+            <br />
+            추가로 생성할 수 있어요.
+          </DisabledText>
+        </Modal>
+      )}
     </>
   );
 }

--- a/src/app/meet/[id]/bill/upsert/page.tsx
+++ b/src/app/meet/[id]/bill/upsert/page.tsx
@@ -8,7 +8,7 @@ import { createBill, getBill, updateBill } from '@/lib/api/bills';
 import { getMeet } from '@/lib/api/meets';
 import useToggle from '@/lib/hooks/useToggle';
 import { Bill } from '@/types/bills';
-import { Meet } from '@/types/meets';
+import { MeetResponse } from '@/types/meets';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
@@ -54,7 +54,7 @@ const BillUpsertPage = () => {
 
   const searchParam = Number(searchParams.get('chargeId'));
 
-  const { data: meet } = useQuery<AxiosResponse<Meet>>({
+  const { data: meet } = useQuery<AxiosResponse<MeetResponse>>({
     queryKey: ['meet'],
     queryFn: () => getMeet(Number(params.id)),
   });

--- a/src/app/meet/[id]/page.tsx
+++ b/src/app/meet/[id]/page.tsx
@@ -9,7 +9,7 @@ import { LargeText, Text } from '@/components/Modal/modalTypography';
 import useToggle from '@/lib/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
-import { Meet, MeetStatus } from '@/types/meets';
+import { MeetResponse, MeetStatus } from '@/types/meets';
 import { getMeet } from '@/lib/api/meets';
 import { useParams } from 'next/navigation';
 import { toDate } from '@/lib/utils/dateUtils';
@@ -29,7 +29,7 @@ function MeetIdPage() {
   const [isOpenModal, toggleOpenModal] = useToggle();
   const [meetStatus, setMeetStatus] = useState<MeetStatus>(MEET_STATUS.SCHEDULE_BEFORE_USE);
 
-  const { data: meet } = useQuery<AxiosResponse<Meet>>({
+  const { data: meet } = useQuery<AxiosResponse<MeetResponse>>({
     queryKey: ['meet', meetId],
     queryFn: () => getMeet(meetId as number),
     enabled: meetId !== null,
@@ -60,7 +60,7 @@ function MeetIdPage() {
     return uniqueMemberIds.size;
   }, [schedules]);
 
-  const findMyMeetId = (meet: Meet) => {
+  const findMyMeetId = (meet: MeetResponse) => {
     return meet.members.find((member) => member.userInfo.isMe === true)?.meetMemberId;
   };
 

--- a/src/components/common/MemberIcon.tsx
+++ b/src/components/common/MemberIcon.tsx
@@ -51,8 +51,8 @@ const MemberIcon: React.FC<MemberIconProps> = ({
   selected = false,
   onClick,
 }) => {
-  if (puzzleId > MAX_BADGE_COUNT) puzzleId = 0; // invalid badge
-  const IconComponent = iconMap[puzzleId];
+  const validPuzzleId = puzzleId > MAX_BADGE_COUNT ? 0 : puzzleId;
+  const IconComponent = iconMap[validPuzzleId] || iconMap[0];
 
   return (
     <IconWrapper

--- a/src/constants/meetConst.ts
+++ b/src/constants/meetConst.ts
@@ -5,3 +5,6 @@ export const MEET_STATUS = {
   PLACE_AFTER_USE: 'PLACE_AFTER_USE', // 장소 이용중 : meetLocation 없고, voteExpiredLocation 있을 때
   BILL: 'BILL', // 장소 완료, 정산 이용 전 : meetLocation 있는 경우 || 약속 끝! : meetDate 지난 경우
 } as const;
+
+export const MAX_UPCOMMING_MEET_COUNT = 4;
+export const MAX_VISIBLE_MEET_MEMBER_ICON_COUNT = 7;

--- a/src/features/home/main/MeetingHistoryGrid/MeetingHistoryGrid.tsx
+++ b/src/features/home/main/MeetingHistoryGrid/MeetingHistoryGrid.tsx
@@ -2,204 +2,62 @@ import React from 'react';
 import styled from 'styled-components';
 import MemberIconStack from '@/features/home/main/MemberIconStack';
 import { useRouter } from 'next/navigation';
+import { HomeMeetsResponse } from '@/types/meets';
 
-const meetings = [
-  {
-    id: 7,
-    title: '쩝쩝이들',
-    isActive: true,
-    members: [
-      {
-        meetMemberId: 1,
-        userInfo: {
-          userId: 101,
-          nickname: '박쌈뽕',
-          puzzleId: 1,
-          puzzleColor: 'blue',
-          isMe: true,
-        },
-      },
-      {
-        meetMemberId: 2,
-        userInfo: {
-          userId: 102,
-          nickname: '빨강이',
-          puzzleId: 2,
-          puzzleColor: 'red',
-        },
-      },
-      {
-        meetMemberId: 3,
-        userInfo: {
-          userId: 103,
-          nickname: '노랑이',
-          puzzleId: 3,
-          puzzleColor: 'yellow',
-        },
-      },
-    ],
-  },
-  {
-    id: 9,
-    title: '15학번이즈백',
-    isActive: false,
-    members: [
-      {
-        meetMemberId: 4,
-        userInfo: {
-          userId: 104,
-          nickname: '초록이',
-          puzzleId: 4,
-          puzzleColor: 'green',
-        },
-      },
-      {
-        meetMemberId: 5,
-        userInfo: {
-          userId: 105,
-          nickname: '보라',
-          puzzleId: 5,
-          puzzleColor: 'purple',
-        },
-      },
-      {
-        meetMemberId: 6,
-        userInfo: {
-          userId: 106,
-          nickname: '검정',
-          puzzleId: 6,
-          puzzleColor: 'black',
-        },
-      },
-    ],
-  },
-  {
-    id: 4,
-    title: '한강 치킨팟',
-    isActive: false,
-    members: [
-      {
-        meetMemberId: 7,
-        userInfo: {
-          userId: 107,
-          nickname: '초록초록',
-          puzzleId: 4,
-          puzzleColor: 'green',
-        },
-      },
-      {
-        meetMemberId: 8,
-        userInfo: {
-          userId: 108,
-          nickname: '보라보라',
-          puzzleId: 5,
-          puzzleColor: 'purple',
-        },
-      },
-      {
-        meetMemberId: 9,
-        userInfo: {
-          userId: 109,
-          nickname: '검정검정',
-          puzzleId: 6,
-          puzzleColor: 'black',
-        },
-      },
-      {
-        meetMemberId: 10,
-        userInfo: {
-          userId: 110,
-          nickname: '파란파랑',
-          puzzleId: 7,
-          puzzleColor: 'blue',
-        },
-      },
-      {
-        meetMemberId: 11,
-        userInfo: {
-          userId: 111,
-          nickname: '빨강빨강',
-          puzzleId: 8,
-          puzzleColor: 'red',
-        },
-      },
-      {
-        meetMemberId: 12,
-        userInfo: {
-          userId: 112,
-          nickname: '노랑노랑',
-          puzzleId: 9,
-          puzzleColor: 'yellow',
-        },
-      },
-      {
-        meetMemberId: 13,
-        userInfo: {
-          userId: 113,
-          nickname: '초록연두',
-          puzzleId: 10,
-          puzzleColor: 'green',
-        },
-      },
-      {
-        meetMemberId: 14,
-        userInfo: {
-          userId: 114,
-          nickname: '보라어스',
-          puzzleId: 11,
-          puzzleColor: 'purple',
-        },
-      },
-    ],
-  },
-];
+type Props = {
+  meets: HomeMeetsResponse;
+};
 
-const MeetingHistoryGrid = () => {
+const MeetingHistoryGrid = ({ meets }: Props) => {
   const router = useRouter();
+
   return (
     <Container>
-      <p className="title">곧 만나요!</p>
-      <BlockContainer>
-        {meetings
-          .filter((meeting) => meeting.isActive)
-          .slice(0, 4)
-          .map((meeting) => (
-            <MeetingBlock
-              key={meeting.id}
-              $isActive={meeting.isActive}
-              onClick={() => {
-                router.push(`/meet/${meeting.id}`);
-              }}
-            >
-              <p className="title">{meeting.title}</p>
-              <Row>
-                <p className="description">인원 {meeting.members.length}명</p>
-                <MemberIconStack members={meeting.members} />
-              </Row>
-            </MeetingBlock>
-          ))}
-      </BlockContainer>
-      <p className="title">즐거웠어요!</p>
-      <BlockContainer>
-        {meetings
-          .filter((meeting) => !meeting.isActive)
-          .slice(0, 4)
-          .map((meeting) => (
-            <MeetingBlock
-              key={meeting.id}
-              $isActive={meeting.isActive}
-              onClick={() => {
-                router.push(`/meet/${meeting.id}`);
-              }}
-            >
-              <p className="title">{meeting.title}</p>
-              <Row>
-                <p className="description">인원 {meeting.members.length}명</p>
-                <MemberIconStack members={meeting.members} />
-              </Row>
-            </MeetingBlock>
-          ))}
-      </BlockContainer>
+      {meets.upcomingMeets.length > 0 && (
+        <>
+          <p className="title">곧 만나요!</p>
+          <BlockContainer>
+            {meets.upcomingMeets.map((meet) => (
+              <MeetingBlock
+                key={meet.meetId}
+                $isActive={true}
+                onClick={() => {
+                  router.push(`/meet/${meet.meetId}`);
+                }}
+              >
+                <p className="title">{meet.meetName}</p>
+                <Row>
+                  <p className="description">인원 {meet.userInfo.length}명</p>
+                  <MemberIconStack members={meet.userInfo} />
+                </Row>
+              </MeetingBlock>
+            ))}
+          </BlockContainer>
+        </>
+      )}
+
+      {meets.pastMeets.length > 0 && (
+        <>
+          <p className="title">즐거웠어요!</p>
+          <BlockContainer>
+            {meets.pastMeets.map((meet) => (
+              <MeetingBlock
+                key={meet.meetId}
+                $isActive={false}
+                onClick={() => {
+                  router.push(`/meet/${meet.meetId}`);
+                }}
+              >
+                <p className="title">{meet.meetName}</p>
+                <Row>
+                  <p className="description">인원 {meet.userInfo.length}명</p>
+                  <MemberIconStack members={meet.userInfo} />
+                </Row>
+              </MeetingBlock>
+            ))}
+          </BlockContainer>
+        </>
+      )}
     </Container>
   );
 };

--- a/src/features/home/main/MemberIconStack/MemberIconStack.tsx
+++ b/src/features/home/main/MemberIconStack/MemberIconStack.tsx
@@ -1,33 +1,31 @@
 import styled from 'styled-components';
-import MemberIcon from '@/components/common/MemberIcon';
 import { MoreHorizontal } from 'react-feather';
 import { Member } from '@/types/meets';
+import MemberIcon from '@/components/common/MemberIcon';
+import { MAX_VISIBLE_MEET_MEMBER_ICON_COUNT } from '@/constants/meetConst';
 
 type IconStackProps = {
   members: Member[];
 };
 
 const MemberIconStack: React.FC<IconStackProps> = ({ members }) => {
-  const MAX_ICONS = 7; // 최대 표시 아이콘 개수
-
   // TODO: members 정렬 필요 여부 Figma 문의함.
-
   return (
     <MembersWrapper>
-      {members.slice(0, MAX_ICONS).map((member, index) => (
+      {members.slice(0, MAX_VISIBLE_MEET_MEMBER_ICON_COUNT).map((member, index) => (
         <StackedIcon
           key={index}
-          style={{ zIndex: MAX_ICONS - index }} // 앞쪽 아이콘이 위로 쌓이도록 설정
+          style={{ zIndex: MAX_VISIBLE_MEET_MEMBER_ICON_COUNT - index }} // 앞쪽 아이콘이 위로 쌓이도록 설정
         >
           <MemberIcon
-            puzzleId={member.userInfo.puzzleId}
-            puzzleColor={member.userInfo.puzzleColor}
+            puzzleId={member.puzzleId}
+            puzzleColor={member.puzzleColor}
             size={40}
             showShadow={true}
           />
         </StackedIcon>
       ))}
-      {members.length > MAX_ICONS && (
+      {members.length > MAX_VISIBLE_MEET_MEMBER_ICON_COUNT && (
         <MoreWrapper>
           <MoreHorizontal />
         </MoreWrapper>

--- a/src/features/meet/bill/BillCreate/BillCreatePrice/BillCreatePrice.tsx
+++ b/src/features/meet/bill/BillCreate/BillCreatePrice/BillCreatePrice.tsx
@@ -6,7 +6,7 @@ import InputWrapper from '@/components/Input/InputWrapper';
 import Button from '@/components/Button';
 import TabBar from '@/components/TabBar';
 import { useSearchParams } from 'next/navigation';
-import { Member } from '@/types/meets';
+import { MeetMember } from '@/types/meets';
 
 type Props = {
   data: {
@@ -15,7 +15,7 @@ type Props = {
     peopleNumber: number;
     memberIds: number[];
   };
-  members: Member[];
+  members: MeetMember[];
   value: string;
   isAllSelected: boolean;
   isFocused: boolean;

--- a/src/features/meet/main/MeetingHeader/MeetingHeader.tsx
+++ b/src/features/meet/main/MeetingHeader/MeetingHeader.tsx
@@ -3,16 +3,17 @@ import React from 'react';
 import styled from 'styled-components';
 import { Share2 } from 'react-feather';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import { Member } from '@/types/meets';
+import { MeetMember } from '@/types/meets';
 
 interface Props {
   onClickShare: () => void;
   meetName: string;
-  members: Member[];
+  members: MeetMember[];
   joinCode: string;
 }
 
 const MeetingHeader = ({ onClickShare, meetName, members, joinCode }: Props) => {
+  const convertedMembers = members.map((member) => member.userInfo);
   return (
     <Container>
       <SpaceBetweenRow>
@@ -23,7 +24,7 @@ const MeetingHeader = ({ onClickShare, meetName, members, joinCode }: Props) => 
       </SpaceBetweenRow>
       <Row>
         <p className="description">인원 {members.length}명</p>
-        <MemberIconStack members={members} />
+        <MemberIconStack members={convertedMembers} />
       </Row>
     </Container>
   );

--- a/src/features/meet/management/ManagementChangeName/ManagementChangeName.tsx
+++ b/src/features/meet/management/ManagementChangeName/ManagementChangeName.tsx
@@ -7,7 +7,7 @@ import { Text } from '@/components/Modal/modalTypography';
 import { useInputState } from '@/hooks/useInputState';
 import { getMeet, updateMeet } from '@/lib/api/meets';
 import useToggle from '@/lib/hooks/useToggle';
-import { Meet } from '@/types/meets';
+import { MeetResponse } from '@/types/meets';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { useRouter } from 'next/navigation';
@@ -26,7 +26,7 @@ function ManagementChangeName() {
   const [isOpenModal, toggleOpenModal] = useToggle();
   const router = useRouter();
 
-  const { data: meet } = useQuery<AxiosResponse<Meet>>({
+  const { data: meet } = useQuery<AxiosResponse<MeetResponse>>({
     queryKey: ['meet'],
     queryFn: () => getMeet(1),
   });

--- a/src/lib/api/meets.ts
+++ b/src/lib/api/meets.ts
@@ -1,7 +1,7 @@
 import { defaultAxios } from '@/lib/api/defaultAxios';
 import { mockMeetData } from './mock/meets';
 import { AxiosResponse } from 'axios';
-import { Meet } from '@/types/meets';
+import { MeetResponse } from '@/types/meets';
 
 // 미팅 개별조회
 // export const getMeet = async (meetId: number): Promise<AxiosResponse<Meet>> => {
@@ -63,9 +63,9 @@ export const createMeet = async (data: { meetName: string }) => {
 };
 
 // 미팅 전체 조회
-// export const getHomeMeets = async () => {
-//   return await defaultAxios.get(`/meets/home`);
-// };
+export const getHomeMeets = async () => {
+  return await defaultAxios.get(`/meets/home`);
+};
 
 // 참여 코드 입력
 export const joinMeet = async (data: { joinCode: string }) => {

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,4 @@
+export type ErrorResponse = {
+  code: string;
+  message: string;
+};

--- a/src/types/meets.ts
+++ b/src/types/meets.ts
@@ -2,28 +2,43 @@
 import { MEET_STATUS } from '@/constants/meetConst';
 
 export type Member = {
-  meetMemberId: number; // 미팅에서의 유저 고유 ID
-  userInfo: {
-    userId: number; // 유저 고유 ID
-    nickname: string; // 닉네임
-    puzzleId: number; // 프로필 퍼즐 ID
-    puzzleColor: string; // 프로필 퍼즐 색상
-    isMe?: boolean; // 본인인지 아닌지
-  };
+  userId: number; // 유저 고유 ID
+  nickname: string; // 닉네임
+  puzzleId: number; // 프로필 퍼즐 ID
+  puzzleColor: string; // 프로필 퍼즐 색상
+  isMe?: boolean; // 본인인지 아닌지
 };
 
-export type Meet = {
+export type MeetMember = {
+  meetMemberId: number; // 미팅에서의 유저 고유 ID
+  userInfo: Member; // 멤버 정보
+};
+
+export type MeetResponse = {
   meetId: number; // 약속 고유 ID
+  joinCode: string; // 약속 참여 코드
   meetName: string; // 약속명
   meetState: string; // 약속 상태값
   meetDate: null | string; // 만남 날짜
   meetLocation: null | string; // 만남 장소
   voteExpiredDate: string; // 날짜 투표 만료일
   voteExpiredLocation: string; // 장소 투표 만료일
-  members: Member[];
+  members: MeetMember[];
+};
+
+export type Meet = {
+  meetId: number; // 모임 ID
+  joinCode: number; // 참여 코드
+  meetName: string; // 모임 이름
+  meetDate: string | null; // 모임 날짜 (YYYY-MM-DD 형식 또는 null)
+  memberCount: number; // 멤버 수
+  userInfo: Member[]; // 멤버 목록
 };
 
 // 홈 미팅 리스트 조회 (최대 4 + 4 = 8개의 미팅만 조회 가능)
-// export type HomeMeets = {};
+export type HomeMeetsResponse = {
+  upcomingMeets: Meet[]; // 다가올 모임 목록
+  pastMeets: Meet[]; // 지난 모임 목록
+};
 
 export type MeetStatus = (typeof MEET_STATUS)[keyof typeof MEET_STATUS];


### PR DESCRIPTION
### ✏️ 작업한 내용
 - [x] 메인 미팅 리스트 조회 API 연동
 - [x] 기존 단건 조회 시 사용되던 Meet 타입을 MeetResponse로 수정
 - [x] 4개 이상의 진행중인 모임 못만들도록 모달 추가