### PR TITLE
feat: 미팅전체조회,개별조회,개별삭제,관리로직 -#60

### DIFF
--- a/src/features/meet/management/ManagementChangeName/ManagementChangeName.tsx
+++ b/src/features/meet/management/ManagementChangeName/ManagementChangeName.tsx
@@ -10,7 +10,7 @@ import useToggle from '@/lib/hooks/useToggle';
 import { MeetResponse } from '@/types/meets';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
@@ -25,10 +25,11 @@ function ManagementChangeName() {
   } = useInputState();
   const [isOpenModal, toggleOpenModal] = useToggle();
   const router = useRouter();
+  const params = useParams();
 
   const { data: meet } = useQuery<AxiosResponse<MeetResponse>>({
     queryKey: ['meet'],
-    queryFn: () => getMeet(1),
+    queryFn: () => getMeet(Number(params.id)),
   });
 
   const updateMeetMutation = useMutation({
@@ -42,8 +43,7 @@ function ManagementChangeName() {
     if (!meet) {
       return;
     }
-
-    updateMeetMutation.mutate({ meetId: meet.data.meetId, meetName });
+    updateMeetMutation.mutate({ meetId: Number(params.id), meetName: meetName });
   };
 
   useEffect(() => {

--- a/src/features/meet/management/ManagementGrid/ManagementContent/ManagementContent.tsx
+++ b/src/features/meet/management/ManagementGrid/ManagementContent/ManagementContent.tsx
@@ -1,30 +1,34 @@
 'use client';
 import Button from '@/components/Button';
+import { Meet } from '@/types/meets';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import styled from 'styled-components';
 
 type ManagementContentProps = {
-  onDelete: () => void;
+  meet: Meet;
+  onDelete: (id: number) => void;
 };
 
-function ManagementContent({ onDelete }: ManagementContentProps) {
+function ManagementContent({ meet, onDelete }: ManagementContentProps) {
   const router = useRouter();
+  console.log(meet);
 
   return (
     <Container>
-      <p className="title">찜닭머그러가자</p>
-      <p className="totalPerson">인원 5명</p>
+      <p className="title">{meet.meetName}</p>
+      <p className="totalPerson">인원 {meet.userInfo.length}명</p>
       <div className="person">
-        <p>김짜장,</p>
-        <p>불닭먹고싶다,</p>
-        <p>마라엽기떡볶이,</p>
-        <p>박짬뽕,</p>
-        <p>지니는찜닭이조아</p>
+        {meet.userInfo.map((user, index) => (
+          <p key={user.userId}>
+            {user.nickname}
+            {index !== meet.userInfo.length - 1 && ','}
+          </p>
+        ))}
       </div>
       <div className="btnGroup">
-        <Button name="미팅 삭제" buttonType="gray" onClick={onDelete} />
-        <Button name="미팅명 변경" onClick={() => router.push('/meet/management/1')} />
+        <Button name="미팅 삭제" buttonType="gray" onClick={() => onDelete(meet.meetId)} />
+        <Button name="미팅명 변경" onClick={() => router.push(`/meet/management/${meet.meetId}`)} />
       </div>
     </Container>
   );

--- a/src/lib/api/meets.ts
+++ b/src/lib/api/meets.ts
@@ -1,61 +1,19 @@
 import { defaultAxios } from '@/lib/api/defaultAxios';
-import { mockMeetData } from './mock/meets';
-import { AxiosResponse } from 'axios';
-import { MeetResponse } from '@/types/meets';
 
 // 미팅 개별조회
-// export const getMeet = async (meetId: number): Promise<AxiosResponse<Meet>> => {
-//   console.log(`Mock API 호출: /meets/${meetId}`);
-//   return new Promise<AxiosResponse<Meet>>((resolve) =>
-//     setTimeout(
-//       () =>
-//         resolve({
-//           data: mockMeetData,
-//           status: 200,
-//           statusText: 'OK',
-//           headers: {},
-//           config: {},
-//           request: {},
-//         } as AxiosResponse<Meet>),
-//       500,
-//     ),
-//   );
-// };
 export const getMeet = async (meetId: number) => {
   return await defaultAxios.get(`/meets/${meetId}`);
 };
 
 // 미팅 개별수정
-export const updateMeet = async ({ meetId, meetName }: { meetId: number; meetName: string }) => {
-  console.log(`Mock API 호출: /meets/${meetId} PATCH, 새로운 미팅명: ${meetName}`);
-  if (meetId === mockMeetData.meetId) {
-    mockMeetData.meetName = meetName;
-  }
-  return new Promise((resolve) => setTimeout(() => resolve(meetName), 500));
+export const updateMeet = async (data: { meetId: number; meetName: string }) => {
+  await defaultAxios.patch(`/meets/${data.meetId}`, data.meetName);
 };
-// export const updateMeet = async (meetId: number, meetName: string) => {
-//   await defaultAxios.patch(`/meets/${meetId}`, { meetName });
-// };
 
 // 미팅 개별삭제
-export const deleteMeet = async (meetId: number): Promise<AxiosResponse> => {
-  console.log(`Mock API 호출: /meets/${meetId} DELETE`);
-  return new Promise<AxiosResponse>((resolve) =>
-    setTimeout(() => {
-      resolve({
-        data: null,
-        status: 204,
-        statusText: 'OK',
-        headers: {},
-        config: {},
-        request: {},
-      } as AxiosResponse);
-    }, 500),
-  );
+export const deleteMeet = async (meetId: number) => {
+  await defaultAxios.delete(`/meets/${meetId}`);
 };
-// export const deleteMeet = async (meetId: number) => {
-//   await defaultAxios.delete(`/meets/${meetId}`);
-// };
 
 // 미팅 생성
 export const createMeet = async (data: { meetName: string }) => {


### PR DESCRIPTION
### Description
> 미팅관리 API 연동을 진행합니다. 

브랜치 :  `feat/manage`

라우팅 
- 미팅 관리 : `meet/management`
- 개별 미팅 상세 관리 : `meet/management/{meetId}`

API 경로 : `lib/api/meets.ts`

목업데이터 : `lib/api/mock/~`


### InProgress 

- [x] 미팅 전체조회 
- [x] 미팅 개별조회 
- [x] 미팅 개별삭제 
- [x] 미팅관리 로직  