### PR TITLE
fix: 일정 생성/추가 API 분리에 따른 수정 -#45

### DIFF
--- a/src/app/meet/[id]/page.tsx
+++ b/src/app/meet/[id]/page.tsx
@@ -115,7 +115,7 @@ function MeetIdPage() {
       votedMemberCount,
     );
 
-    if (voteExpiredDate === null) {
+    if (voteExpiredDate === null || votedMemberCount === 0) {
       // 미팅 시작 전
       setMeetStatus(MEET_STATUS.SCHEDULE_BEFORE_USE);
     } else if (!meetDate && voteExpiredDate) {

--- a/src/app/meet/[id]/schedule/page.tsx
+++ b/src/app/meet/[id]/schedule/page.tsx
@@ -57,7 +57,7 @@ function SchedulePage() {
   const setFinalDateMutation = useMutation({
     mutationFn: setFinalDate,
     onSuccess: () => {
-      router.push(`/meet/${meetId}/schedule`);
+      toggleSubmitModal();
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       if (error.response?.data.code === 'VD004') {

--- a/src/features/meet/main/MeetingContents/MeetingDateItem.tsx
+++ b/src/features/meet/main/MeetingContents/MeetingDateItem.tsx
@@ -18,7 +18,11 @@ const MeetingDateItem = ({
   warningMessage,
 }: Props) => {
   const status: 'notStarted' | 'inProgress' | 'completed' =
-    meetDate !== null ? 'completed' : voteExpiredDate !== null ? 'inProgress' : 'notStarted';
+    meetDate !== null
+      ? 'completed'
+      : voteExpiredDate === null || votedMembers === 0
+        ? 'notStarted'
+        : 'inProgress';
 
   const voteResult = meetDate ? formatDateToMMDD(meetDate) : '';
 

--- a/src/lib/api/schedules.ts
+++ b/src/lib/api/schedules.ts
@@ -26,7 +26,7 @@ export const editSchedule = async ({
   meetId: number;
   data: UpdateScheduleData;
 }) => {
-  return await defaultAxios.post(`/meets/${meetId}/vote/date`, data);
+  return await defaultAxios.patch(`/meets/${meetId}/vote/date`, data);
 };
 
 export const setFinalDate = async ({


### PR DESCRIPTION
### 작업 내용
- 백단 일정 생성 API 용도가 변경되었습니다.
- 설명 : 일정 초기 생성 시 POST, 두 번째 유저부터는 PATCH


### 추후 확인 사항
- 백단에서 POST API 호출 시 기생성된 일정이 있으면 생성 안되도록 에러 처리 추가 요청한 상황.
  - **추후 모달 띄우도록 작업 필요**
- DELETE API 호출 후(재투표 버튼 클릭) 미팅 단건 조회 시 현재 voteExpiredDate필드에 기존값이 남아있음
   - voteExpiredDate가 있으면 미팅 현황 페이지에서 0건이지만 진행중 표시가 뜨게 됨.
     - 방어코드로 투표한 멤버 수도 체크하도록 조건 추가함.
   - 추후 API 수정 완료되면 null로 날아갔는지 확인하고, 미팅 상태 제대로 뜨는지 **확인 필요**