### PR TITLE
fix: DefaultAxios 요청 시 content type을 json으로 수정 -#105

### DIFF
--- a/src/lib/api/defaultAxios.ts
+++ b/src/lib/api/defaultAxios.ts
@@ -6,6 +6,9 @@ const baseURL = `${process.env.NEXT_PUBLIC_SERVER_URL}`;
 export const defaultAxios = axios.create({
   baseURL,
   withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
 
 // Request Interceptor


### PR DESCRIPTION
### 작업한 내용
- 미팅 명 수정 API request의 데이터 타입을 `application/x-www-form-urlencoded`에서 `application/json`으로 변경